### PR TITLE
add digital twin files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,23 @@ Key modules:
 
 ---
 
-## How to Cite
+## How to Cite - List of Papers, Depending on 
 
 ```bibtex
+# for pixel wise, yolo from v8 to v11
+@article{PCPDALUZ2026101858,
+title = {Smart parking with pixel-wise ROI selection for vehicle detection using YOLOv8, YOLOv9, YOLOv10, and YOLOv11},
+journal = {Internet of Things},
+volume = {36},
+pages = {101858},
+year = {2026},
+issn = {2542-6605},
+doi = {https://doi.org/10.1016/j.iot.2025.101858},
+url = {https://www.sciencedirect.com/science/article/pii/S2542660525003725},
+author = {Gustavo {P C P da Luz} and Gabriel {Massuyoshi Sato} and Luis {Fernando Gomez Gonzalez} and Juliana {Freitag Borin}},
+}
+
+# old version
 @article{da2024smart,
   title={Smart Parking with Pixel-Wise ROI Selection for Vehicle Detection Using YOLOv8, YOLOv9, YOLOv10, and YOLOv11},
   author={da Luz, Gustavo PCP and Sato, Gabriel Massuyoshi and Gonzalez, Luis Fernando Gomez and Borin, Juliana Freitag},
@@ -145,6 +159,7 @@ Key modules:
   doi= {10.48550/arXiv.2412.01983}
 }
 
+# for deployment, history, maskrcnn, yolov3, yolov11 tflite
 @inproceedings{da202510,
   author = {Gustavo da Luz and Gabriel Sato and Tiago Bannwart and Luis Gonzalez and Juliana Borin},
   title = {10 Years of Deep Learning for Vehicle Detection at a Smart Parking : What has Changed?},
@@ -157,6 +172,23 @@ Key modules:
   doi = {10.5753/courb.2025.8869},
   url = {https://sol.sbc.org.br/index.php/courb/article/view/35256}
 }
+
+# for the tv box server
+@inproceedings{score,
+ author = {Tiago Bannwart and Gustavo Luz and Gabriel Sato and Luis Gonzalez and Juliana Borin},
+ title = { TV Boxes as Support Servers for IoT Applications},
+ booktitle = {Anais do I Workshop on Sustainable Computing and Technology Reuse},
+ location = {Campinas/SP},
+ year = {2025},
+ keywords = {},
+ issn = {0000-0000},
+ pages = {1--4},
+ publisher = {SBC},
+ address = {Porto Alegre, RS, Brasil},
+ doi = {10.5753/score.2025.17175},
+ url = {https://sol.sbc.org.br/index.php/score/article/view/39613}
+}
+
 ```
 
 ---

--- a/digital_twin/README.md
+++ b/digital_twin/README.md
@@ -1,0 +1,3 @@
+# Digital Twin Setup
+
+Add here instructions to set digital twin and in this folder all code necessary.

--- a/digital_twin/modeled-entities-json/Building.json
+++ b/digital_twin/modeled-entities-json/Building.json
@@ -1,0 +1,47 @@
+{
+    "id": "urn:ngsi-ld:Building:IC2",
+    "type": "Building",
+    "category": {
+        "type": "Property",
+        "value": ["university"]
+     },
+    "description": {
+        "type": "Property",
+	"value": "IC-2 is one of the main buildings of the Institute of Computing (IC) at the University of Campinas (Unicamp), located at Av. Albert Einstein, 1251, within the Campinas campus. Together with IC-1, it hosts offices for faculty and staff, a 60-seat auditorium, research laboratories, rooms for PhD and postdoctoral researchers, and the secretariats of undergraduate, graduate, extension, and research support activities."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+	   "addressCountry": "Brazil",
+	   "addressLocality": "Campinas",
+	   "addressRegion": "São Paulo",
+	   "district": "Barão Geraldo",
+	   "postOfficeBoxNumber": "13083",
+	   "postalCode": "13083-852",
+	   "streetAddress": "Avenida Albert Einstein",
+	   "streetNr": "1251"
+         }
+    },
+    "location": {
+       "type": "GeoProperty",
+       "value": {
+          "type": "Polygon",
+	  "coordinates": [[
+	     [-47.065108, -22.815020],
+	     [-47.06452, -22.81457],
+	     [-47.06436, -22.81493],
+	     [-47.06505,-22.81517],
+	     [-47.065108, -22.815020]
+	  ]]
+       }
+    },
+    "mapUrl": {
+       "type": "Property",
+       "value": "https://maps.app.goo.gl/PDJ75quJoUGZj2k36"
+    },
+    "name": {
+       "type": "Property",
+       "value": "IC-2 Building"
+    }
+
+}

--- a/digital_twin/modeled-entities-json/Group-DisabledOnly.json
+++ b/digital_twin/modeled-entities-json/Group-DisabledOnly.json
@@ -1,0 +1,71 @@
+{
+    "id": "urn:ngsi-ld:ParkingGroup:IC2-Staff-DisabledOnly",
+    "type": "ParkingGroup",
+    "description": {
+        "type": "Property",
+	"value": "Parking group reserved exclusively for only disabled IC staff members. Located near the IC2 Building, it provides free parking with no fee required. It contains 2 parking spots."
+    },
+    "availableSpotNumber": {
+       "type": "Property",
+       "value": 0
+    },
+    "category": {
+       "type": "Property",
+       "value": ["offStreet", "onlyDisabled", "free"]
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+	   "addressCountry": "Brazil",
+	   "addressLocality": "Campinas",
+	   "addressRegion": "São Paulo",
+	   "district": "Barão Geraldo",
+	   "postOfficeBoxNumber": "13083",
+	   "postalCode": "13083-852",
+	   "streetAddress": "Avenida Albert Einstein",
+	   "streetNr": "1251"
+         }
+    },
+    "location": {
+       "type": "GeoProperty",
+       "value": {
+          "type": "Polygon",
+	  "coordinates": [
+             [
+                [-47.06438285382501, -22.81478224778894],
+                [-47.064345449315766, -22.814768967454086],
+                [-47.064329421964516, -22.814805629597885],
+                [-47.06436582345387, -22.814817188427085],
+		        [-47.06438285382501, -22.81478224778894]
+             ]
+          ]
+       }
+    },
+    "name": {
+       "type": "Property",
+       "value": "IC-2 only disabled Staff Parking Group"
+    },
+    "occupancyDetectionType": {
+       "type": "Property",
+       "value": [ "singleSpaceDetection" ]
+    },
+    "parkingMode": {
+       "type": "Property",
+       "value": ["perpendicularParking"]
+    },
+    "refParkingSite": {
+       "type": "Relationship",
+       "object": ["urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"]
+    },
+    "refParkingSpot": {
+      "type": "Relationship",
+      "object": [
+        "urn:ngsi-ld:ParkingSpot:IC2-008",
+        "urn:ngsi-ld:ParkingSpot:IC2-009"
+      ]
+    },
+    "totalSpotNumber": {
+       "type": "Property",
+       "value": 2
+    }
+}

--- a/digital_twin/modeled-entities-json/Group-General.json
+++ b/digital_twin/modeled-entities-json/Group-General.json
@@ -1,0 +1,95 @@
+{
+    "id": "urn:ngsi-ld:ParkingGroup:IC2-Staff",
+    "type": "ParkingGroup",
+    "description": {
+        "type": "Property",
+	"value": "Parking group reserved exclusively for IC staff members. Located near the IC2 Building, it provides free parking with no fee required. It contains 14 parking spots."
+    },
+    "availableSpotNumber": {
+       "type": "Property",
+       "value": 14
+    },
+    "category": {
+       "type": "Property",
+       "value": ["offStreet", "onlyStaff", "free"]
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+	   "addressCountry": "Brazil",
+	   "addressLocality": "Campinas",
+	   "addressRegion": "São Paulo",
+	   "district": "Barão Geraldo",
+	   "postOfficeBoxNumber": "13083",
+	   "postalCode": "13083-852",
+	   "streetAddress": "Avenida Albert Einstein",
+	   "streetNr": "1251"
+         }
+    },
+    "location": {
+       "type": "GeoProperty",
+       "value": {
+          "type": "MultiPolygon",
+	  "coordinates": [
+             [
+                [
+                   [-47.064275, -22.814762],
+                   [-47.06421, -22.814915],
+                   [-47.06417, -22.8149],
+                   [-47.06423718108387, -22.814749257606973],
+                   [-47.064275, -22.814762]
+                ]
+             ],
+             [
+                [
+                   [-47.064353, -22.81484],
+                   [-47.06431838919067, -22.814829257608338],
+                   [-47.06427, -22.814938],
+                   [-47.064304, -22.814951],
+		   [-47.064353, -22.81484]
+                ]
+             ]
+          ]
+       }
+    },
+    "name": {
+       "type": "Property",
+       "value": "IC-2 Staff Parking Group"
+    },
+    "occupancyDetectionType": {
+       "type": "Property",
+       "value": [ "singleSpaceDetection" ]
+    },
+    "parkingMode": {
+       "type": "Property",
+       "value": ["perpendicularParking"]
+    },
+    "refParkingSite": {
+       "type": "Relationship",
+       "object": ["urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"]
+    },
+    "refParkingSpot": {
+      "type": "Relationship",
+      "object": [
+        "urn:ngsi-ld:ParkingSpot:IC2-000",
+        "urn:ngsi-ld:ParkingSpot:IC2-001",
+        "urn:ngsi-ld:ParkingSpot:IC2-002",
+        "urn:ngsi-ld:ParkingSpot:IC2-003",
+        "urn:ngsi-ld:ParkingSpot:IC2-004",
+        "urn:ngsi-ld:ParkingSpot:IC2-005",
+        "urn:ngsi-ld:ParkingSpot:IC2-006",
+        "urn:ngsi-ld:ParkingSpot:IC2-007",
+        "urn:ngsi-ld:ParkingSpot:IC2-010",
+        "urn:ngsi-ld:ParkingSpot:IC2-011",
+        "urn:ngsi-ld:ParkingSpot:IC2-012",
+        "urn:ngsi-ld:ParkingSpot:IC2-013",
+        "urn:ngsi-ld:ParkingSpot:IC2-014",
+        "urn:ngsi-ld:ParkingSpot:IC2-015"
+      ]
+    },
+    "totalSpotNumber": {
+       "type": "Property",
+       "value": 14
+    }
+
+}

--- a/digital_twin/modeled-entities-json/OffStreetParking.json
+++ b/digital_twin/modeled-entities-json/OffStreetParking.json
@@ -1,0 +1,120 @@
+{
+    "id": "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking",
+    "type": "OffStreetParking",
+    "category": {
+        "type": "Property",
+        "value": ["forDisabled", "forMembers", "free", "public"]
+     },
+    "description": {
+        "type": "Property",
+	"value": "Off Street Parking in front of the IC2 Building with 16 available spots."
+    },
+    "images": {
+       "type": "Property",
+       "value": ["https://www.google.com/maps/@-22.8147513,-47.0641531,3a,90y,237.55h,76.96t/data=!3m7!1e1!3m5!1sa62i4VHs2IMgyVVkxG5-DQ!2e0!6shttps:%2F%2Fstreetviewpixels-pa.googleapis.com%2Fv1%2Fthumbnail%3Fcb_client%3Dmaps_sv.tactile%26w%3D900%26h%3D600%26pitch%3D13.035531924836505%26panoid%3Da62i4VHs2IMgyVVkxG5-DQ%26yaw%3D237.55290115083352!7i13312!8i6656?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D"]
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+	   "addressCountry": "Brazil",
+	   "addressLocality": "Campinas",
+	   "addressRegion": "São Paulo",
+	   "district": "Barão Geraldo",
+	   "postOfficeBoxNumber": "13083",
+	   "postalCode": "13083-852",
+	   "streetAddress": "Avenida Albert Einstein",
+	   "streetNr": "1251"
+         }
+    },
+    "availableSpotNumber": {
+       "type": "Property",
+       "value": 10
+    },
+    "location": {
+       "type": "GeoProperty",
+       "value": {
+          "type": "Polygon",
+	  "coordinates": [[
+	     [-47.06433, -22.81496],
+	     [-47.06439, -22.81476],
+	     [-47.06421, -22.81470],
+	     [-47.06412,-22.81488],
+	     [-47.06433, -22.81496]
+	  ]]
+       }
+    },
+    "name": {
+       "type": "Property",
+       "value": "IC2 OffStreet Parking"
+    },
+    "occupancy": {
+       "type": "Property",
+       "value": 0.5
+    },
+    "occupancyDetectionType": {
+       "type": "Property",
+       "value": [
+          "singleSpaceDetection", "modelBased"
+       ]
+    },
+    "occupiedSpotNumber": {
+       "type": "Property",
+       "value": 5
+    },
+    "owner": {
+       "type": "Property",
+       "value": ["urn:ngsi-ld:Organization:IC"]
+    },
+    "parkingMode": {
+       "type": "Property",
+       "value": ["parallelParking"]
+    },
+    "refBuilding": {
+      "type": "Relationship",
+      "object": ["urn:ngsi-ld:Building:IC2"]
+    },
+    "refParkingGroup": {
+       "type": "Relationship",
+       "object": [
+          "urn:ngsi-ld:ParkingGroup:IC2-Staff",
+	  "urn:ngsi-ld:ParkingGroup:IC2-Staff-DisabledOnly"
+       ]
+    },
+    "refParkingSensor": {
+      "type": "Relationship",
+      "object": ["urn:ngsi-ld:IC2-ParkingSensor"]
+    }
+    "refParkingSpot": {
+       "type": "Relationship",
+       "object": [
+          "urn:ngsi-ld:ParkingSpot:IC2-000",
+          "urn:ngsi-ld:ParkingSpot:IC2-001",
+          "urn:ngsi-ld:ParkingSpot:IC2-002",
+          "urn:ngsi-ld:ParkingSpot:IC2-003",
+          "urn:ngsi-ld:ParkingSpot:IC2-004",
+          "urn:ngsi-ld:ParkingSpot:IC2-005",
+          "urn:ngsi-ld:ParkingSpot:IC2-006",
+          "urn:ngsi-ld:ParkingSpot:IC2-007",
+          "urn:ngsi-ld:ParkingSpot:IC2-008",
+          "urn:ngsi-ld:ParkingSpot:IC2-009",
+          "urn:ngsi-ld:ParkingSpot:IC2-010",
+          "urn:ngsi-ld:ParkingSpot:IC2-011",
+          "urn:ngsi-ld:ParkingSpot:IC2-012",
+          "urn:ngsi-ld:ParkingSpot:IC2-013",
+          "urn:ngsi-ld:ParkingSpot:IC2-014",
+          "urn:ngsi-ld:ParkingSpot:IC2-015"	  
+       ]
+    },
+    "refParkingTotem": {
+      "type": "Relationship",
+      "object": ["urn:ngsi-ld:Totem:IC2-Totem"]
+    },
+    "status": {
+       "type": "Property",
+       "value": ["spacesAvailable"]
+    },
+    "totalSpotNumber": {
+       "type": "Property",
+       "value": 16
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSensor.json
+++ b/digital_twin/modeled-entities-json/ParkingSensor.json
@@ -1,0 +1,39 @@
+{
+    "id": "urn:ngsi-ld:ParkingSensor:IC2",
+    "type": "ParkingSensor",
+    "description": {
+        "type": "Property",
+        "value": "Parking Sensor installed in the IC2 building, it is a raspberry pi equipped with a camera."
+    },
+    "deviceType": {
+      "type": "Property",
+      "value": "raspberryPi-camera"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064242413877196,
+                -22.814635803933584
+            ]
+        }
+    },
+    "measurementType": {
+      "type": "Property",
+      "value": "parkingSpotOccupancy"
+    },
+    "name": {
+      "type": "Property",
+      "value": "IC2-ParkingSensor"
+    },
+    "numValue": {
+      "type": "Property",
+      "value": 0
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-IC2-OffStreetParking"]
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-00.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-00.json
@@ -1,0 +1,58 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-000",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 00 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064251959883066,
+                -22.81476512075327
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-01.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-01.json
@@ -1,0 +1,58 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-001",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 01 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06424369856532,
+                -22.814784104652833
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-02.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-02.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-002",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 02 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06423543724758,
+                -22.8148030885524
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-03.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-03.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-003",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 03 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06422717592984,
+                -22.81482207245196
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-04.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-04.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-004",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 04 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.0642189146121,
+                -22.814841056351526
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-05.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-05.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-005",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 05 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06421065329436,
+                -22.81486004025109
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-06.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-06.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-006",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 06 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06420239197661,
+                -22.814879024150656
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-07.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-07.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-007",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 07 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06419413065887,
+                -22.814898008050218
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-08.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-08.json
@@ -1,0 +1,58 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-008",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 08 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06436001935509,
+                -22.814784557969254
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff-DisabledOnly"]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-09.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-09.json
@@ -1,0 +1,58 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-009",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 09 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064351754924495,
+                -22.81480245866474
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff-DisabledOnly"]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-10.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-10.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-010",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 10 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06433163671239,
+                -22.814843784737157
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-11.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-11.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-011",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 11 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064323520946495,
+                -22.81486209660313
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-12.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-12.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-012",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 12 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06431540518061,
+                -22.8148804084691
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-13.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-13.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-013",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 13 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.06430728941473,
+                -22.81489872033507
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-14.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-14.json
@@ -1,0 +1,59 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-014",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": [
+            "offStreet"
+        ]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 14 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+            "addressCountry": "Brazil",
+            "addressLocality": "Campinas",
+            "addressRegion": "São Paulo",
+            "district": "Barão Geraldo",
+            "postOfficeBoxNumber": "13083",
+            "postalCode": "13083-852",
+            "streetAddress": "Avenida Albert Einstein",
+            "streetNr": "1251"
+        }
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064299173648834,
+                -22.814917032201045
+            ]
+        }
+    },
+    "refDevice": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingSensor:IC2"
+        ]
+    },
+    "refParkingGroup": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:ParkingGroup:IC2-Staff"
+        ]
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"
+        ]
+    },
+    "status": {
+        "type": "Property",
+        "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/ParkingSpot-15.json
+++ b/digital_twin/modeled-entities-json/ParkingSpot-15.json
@@ -1,0 +1,48 @@
+{
+    "id": "urn:ngsi-ld:ParkingSpot:IC2-015",
+    "type": "ParkingSpot",
+    "category": {
+        "type": "Property",
+        "value": ["offStreet"]
+     },
+    "description": {
+        "type": "Property",
+        "value": "Parking spot 15 located near the entrance of the IC2 Building, reserved for staff vehicles."
+    },
+    "address": {
+        "type": "Property",
+        "value": {
+           "addressCountry": "Brazil",
+           "addressLocality": "Campinas",
+           "addressRegion": "São Paulo",
+           "district": "Barão Geraldo",
+           "postOfficeBoxNumber": "13083",
+           "postalCode": "13083-852",
+           "streetAddress": "Avenida Albert Einstein",
+           "streetNr": "1251"
+         }
+    },
+    "location": {
+       "type": "GeoProperty",
+       "value": {
+          "type": "Point",
+          "coordinates": [-47.06429105788294, -22.814935344067017]
+       }
+    },
+    "refDevice": {
+      "type": "Relationship",
+      "object": ["urn:ngsi-ld:ParkingSensor:IC2"]
+    },
+    "refParkingGroup": {
+       "type": "Relationship",
+       "object": ["urn:ngsi-ld:ParkingGroup:IC2-Staff"]
+    },
+    "refParkingSite": {
+      "type": "Relationship",
+      "object": ["urn:ngsi-ld:OffStreetParking:IC2-OffStreetParking"]
+    },
+    "status": {
+       "type": "Property",
+       "value": "free"
+    }
+}

--- a/digital_twin/modeled-entities-json/Totem.json
+++ b/digital_twin/modeled-entities-json/Totem.json
@@ -1,0 +1,60 @@
+{
+    "id": "urn:ngsi-ld:Totem:IC2-Totem",
+    "type": "Totem",
+    "address": {
+        "type": "Property",
+        "value": {
+	   "addressCountry": "Brazil",
+	   "addressLocality": "Campinas",
+	   "addressRegion": "São Paulo",
+	   "district": "Barão Geraldo",
+	   "postOfficeBoxNumber": "13083",
+	   "postalCode": "13083-852",
+	   "streetAddress": "Avenida Albert Einstein",
+	   "streetNr": "1251"
+         }
+    },
+    "areaServed": {
+      "type": "Property",
+      "value": "IC2 Parking"
+    },
+    "category": {
+      "type": "Property",
+      "value": ["multimedia"]
+    },
+    "controlledProperty": {
+      "type": "Property",
+      "value": ["occupancy"]
+    },
+    "description": {
+        "type": "Property",
+        "value": "Totem to show the number of available spots of the IC2 Parking for incoming drivers."
+    },
+    "deviceCategory": {
+      "type": "Property",
+      "value": ["multimedia"]
+    },
+    "deviceState": {
+      "type": "Property",
+      "value": "operational"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -47.064378585396156,
+                -22.81481664875838
+            ]
+        }
+    },
+    "refParkingSite": {
+        "type": "Relationship",
+        "object": [
+            "urn:ngsi-ld:OffStreetParking:IC2-IC2-OffStreetParking"]
+    },
+    "value": {
+      "type": "Property",
+      "value": 0
+    }
+}


### PR DESCRIPTION
adding digital twin files for paper: Spot-wise smart parking: An edge-enabled architecture with YOLOv11 towards a digital twin.